### PR TITLE
Fix an error caused by node 14

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default function progress(options = {}) {
   try {
     total = fs.readFileSync(totalFilePath);
   } catch (e) {
-    fs.writeFileSync(totalFilePath, 0);
+    fs.writeFileSync(totalFilePath, "0");
   }
   const progress = {
     total: total,


### PR DESCRIPTION
In node 14, number is not a valid data type of fs.writeFileSync.
![image](https://user-images.githubusercontent.com/14858674/80375980-b8e55f80-88cb-11ea-9cd5-a099cbedb0b0.png)
